### PR TITLE
コンパイル警告を修正

### DIFF
--- a/OpenXLSX/external/zippy/zippy.hpp
+++ b/OpenXLSX/external/zippy/zippy.hpp
@@ -9857,7 +9857,7 @@ namespace Zippy::Impl
 
         std::random_device                 rand_dev;
         std::mt19937                       generator(rand_dev());
-        std::uniform_int_distribution<int> distr(0, letters.size() - 1);
+        std::uniform_int_distribution<int> distr(0, static_cast<int>(letters.size()) - 1);
 
         std::string result;
         for (int i = 0; i < length; ++i) {
@@ -10812,7 +10812,7 @@ namespace Zippy
         {
             if (!IsOpen()) throw ZipLogicError("Cannot call GetNumEntries on empty ZipArchive object!");
 
-            return GetEntryNames(includeDirs, includeFiles).size();
+            return static_cast<int>(GetEntryNames(includeDirs, includeFiles).size());
         }
 
         /**
@@ -10827,7 +10827,7 @@ namespace Zippy
         {
             if (!IsOpen()) throw ZipLogicError("Cannot call GetNumEntriesInDir on empty ZipArchive object!");
 
-            return GetEntryNamesInDir(dir, includeDirs, includeFiles).size();
+            return static_cast<int>(GetEntryNamesInDir(dir, includeDirs, includeFiles).size());
         }
 
         /**
@@ -11091,7 +11091,7 @@ namespace Zippy
             auto folders = GetEntryNames(true, false);
             auto pos     = 0;
             while (name.find('/', pos) != std::string::npos) {
-                pos         = name.find('/', pos) + 1;
+                pos         = static_cast<int>(name.find('/', pos)) + 1;
                 auto folder = name.substr(0, pos);
 
                 // ===== If folder isn't registered in the archive, add it.

--- a/OpenXLSX/headers/XLStyles.hpp
+++ b/OpenXLSX/headers/XLStyles.hpp
@@ -2123,7 +2123,7 @@ namespace OpenXLSX
          * @brief
          * @param other
          */
-        XLStyles(const XLStyles& other) = default;
+        XLStyles(const XLStyles& other) = delete;
 
         /**
          * @brief
@@ -2136,7 +2136,7 @@ namespace OpenXLSX
          * @param other
          * @return
          */
-        XLStyles& operator=(const XLStyles& other) = default;
+        XLStyles& operator=(const XLStyles& other) = delete;
 
         /**
          * @brief

--- a/OpenXLSX/sources/XLCellIterator.cpp
+++ b/OpenXLSX/sources/XLCellIterator.cpp
@@ -269,7 +269,7 @@ void XLCellIterator::updateCurrentCell(bool createIfMissing)
             XMLNode rowNode = m_hintNode.parent().next_sibling_of_type(pugi::node_element);
             uint32_t rowNo = 0;
             while (not rowNode.empty()) {
-                rowNo = rowNode.attribute("r").as_ullong();
+                rowNo = static_cast<uint32_t>(rowNode.attribute("r").as_ullong());
                 if (rowNo >= m_currentRow) break; // if desired row was reached / passed, break before incrementing rowNode
                 rowNode = rowNode.next_sibling_of_type(pugi::node_element);
             }

--- a/OpenXLSX/sources/XLCellReference.cpp
+++ b/OpenXLSX/sources/XLCellReference.cpp
@@ -291,7 +291,7 @@ uint32_t XLCellReference::rowAsNumber(const std::string& row)
     std::from_chars(row.data(), row.data() + row.size(), value);    // NOLINT
     return value;
 #else
-    return stoul(row);
+    return static_cast<uint32_t>(stoul(row));
 #endif
 }
 

--- a/OpenXLSX/sources/XLRelationships.cpp
+++ b/OpenXLSX/sources/XLRelationships.cpp
@@ -130,7 +130,7 @@ namespace OpenXLSX { // anonymous namespace: do not export these symbols
      */
     void InitRandom(bool pseudoRandom)
     {
-        uint64_t rdSeed;
+        uint32_t rdSeed;
         if (pseudoRandom) rdSeed = 3744821255L; // in pseudo-random mode, always use the same seed
         else {
             std::random_device rd;


### PR DESCRIPTION
暗黙の型キャストが生じている警告が出ているので明示的に修正

デフォルトのコピーコンストラクタと、コピーオペレータが、
moveonlyなメンバがあることで実は生成されていない。
それが警告されるので、デフォルト指定の代わりに削除指定に修正。