### PR TITLE
upstreamしやすいように警告対策パッチを外す

### DIFF
--- a/OpenXLSX/headers/XLStyles.hpp
+++ b/OpenXLSX/headers/XLStyles.hpp
@@ -2123,7 +2123,7 @@ namespace OpenXLSX
          * @brief
          * @param other
          */
-        XLStyles(const XLStyles& other) = delete;
+        XLStyles(const XLStyles& other) = default;
 
         /**
          * @brief
@@ -2136,7 +2136,7 @@ namespace OpenXLSX
          * @param other
          * @return
          */
-        XLStyles& operator=(const XLStyles& other) = delete;
+        XLStyles& operator=(const XLStyles& other) = default;
 
         /**
          * @brief


### PR DESCRIPTION
upstreamでは綺麗に解決しているので、それを取り込みやすいように一旦巻き戻す